### PR TITLE
Update README: s/,/;/ s/every/all/ s/notably //

### DIFF
--- a/README
+++ b/README
@@ -5,11 +5,11 @@ Website: http://github.com/jfmoy/Fraise
 
 Here we are, the fruit is mature. Fraise 3.7.2 has just been released. This version should be bug-free but refactoring from Smultron could have brought some bugs that I haven't noticed yet so please report any bug you will encounter. I also wait for any remarks concerning Fraise and I hope I will have your support as with Smultron 3.7.1. Please spread the word around you concerning this new release!
 
-Now it is time to taste Fraise, I hope you will like it.
+Now it is time to taste Fraise; I hope you will like it.
 
 Important message:
 
-I have removed every translations that have not been updated because notably they don't contain references to the new update system and other new features. If you want to translate Fraise in your language, please contact me (a big part of the application is already translated in multiple languages so it won't require a lot of time).
+I have removed all translations that have not been updated because they don't contain references to the new update system and other new features. If you want to translate Fraise in your language, please contact me (a big part of the application is already translated in multiple languages so it won't require a lot of time).
 
 Changelog:
 


### PR DESCRIPTION
copy of https://github.com/jfmoy/Fraise/pull/46

Three minor changes:
1. Changed a comma between two independent clauses to a semicolon.
2. Changed "every translations" to "all translations", to match the (plural) number used through the rest of the sentence.
3. Removed the word "notably " from "because notably they don't contain", as 
a. it was unnecessary (superfluous, extra), and
b. no other reasons were given, thus the reason given was *the* reason, not just notable as one among the reasons.

Thanks,
annag